### PR TITLE
custom iframe app sends invalid `ox_token`

### DIFF
--- a/ui/apps/io.ox/core/tk/iframe.js
+++ b/ui/apps/io.ox/core/tk/iframe.js
@@ -76,7 +76,7 @@ define('io.ox/core/tk/iframe', [
 
             if (data && data.token) {
 
-                urlWithOxToken = /[?]/.test(url) ? url + '&ox_token=' + data.token : url + '?ox_token=' + data.token;
+                urlWithOxToken = /[?]/.test(url) ? url + '&ox_token=' + encodeURIComponent(data.token) : url + '?ox_token=' + encodeURIComponent(data.token);
 
                 iframe.attr('src', urlWithOxToken);
             }


### PR DESCRIPTION
When using the `io.ox/core/tk/iframe` with the option `acquireToken`, the token is sent without being URL-encoded. 
Since the token is a base64 string, it should be URL-encoded.