### PR TITLE
Fix `config` prototype-polluting function

### DIFF
--- a/ui/apps/io.ox/core/config.js
+++ b/ui/apps/io.ox/core/config.js
@@ -43,6 +43,10 @@ define.async('io.ox/core/config', ['io.ox/core/http', 'io.ox/core/cache'], funct
         var parts = typeof key === 'string' ? key.split(/\./) : key,
             tmp = config || {}, i = 0, $i = parts.length;
         for (; i < $i; i++) {
+            if (parts[i] === '__proto__' || parts[i] === 'constructor') {
+                console.error('config.set: Attempt to modify a dangerous property: ' + parts[i]);
+                return;
+            }
             if (tmp[parts[i]]) {
                 tmp = tmp[parts[i]];
                 if (typeof tmp !== 'object') {


### PR DESCRIPTION
https://github.com/open-xchange/appsuite-frontend/blob/c4051eaec809de7f0d32f4fc3d1040f701fcd030/ui/apps/io.ox/core/config.js#L56-L56

Fix the issue, we need to prevent the `set` function from assigning to dangerous properties like `__proto__` or `constructor`. This can be achieved by adding a check to skip these property names during the recursive assignment process. Additionally, we should ensure that the `key` parameter is validated or sanitized before use.

The fix involves:
1. Adding a check to skip dangerous property names (`__proto__` and `constructor`) in the `set` function.
2. Ensuring that the `parts` array does not contain these dangerous property names before proceeding with the assignment.

The changes will be made in the `set` function in the file `ui/apps/io.ox/core/config.js`.

---


